### PR TITLE
Options de personnalisation de la caméra

### DIFF
--- a/handspeak/src/app/test-camera/page.tsx
+++ b/handspeak/src/app/test-camera/page.tsx
@@ -1,11 +1,21 @@
 "use client";
 
 import Camera from "@/components/Camera";
-import { Category } from "@mediapipe/tasks-vision";
-import { useState } from "react";
+import { Category, GestureRecognizerOptions } from "@mediapipe/tasks-vision";
+import { useMemo, useState } from "react";
 
 export default function TestCamera() {
 	const [resultat, setResultat] = useState<Category>();
+	const options: GestureRecognizerOptions = useMemo(
+		() => ({
+			minHandDetectionConfidence: 0.9,
+			cannedGesturesClassifierOptions: {
+				scoreThreshold: 0.8,
+				categoryDenylist: ["Thumb_Down"],
+			},
+		}),
+		[]
+	);
 	return (
 		<div className="flex flex-col gap-2 items-center">
 			<p className="text-center text-xl p-2">
@@ -14,6 +24,7 @@ export default function TestCamera() {
 				{Math.round((resultat?.score || 0) * 100)} %
 			</p>
 			<Camera
+				options={options}
 				modelePath={`${process.cwd()}modeles/gesture_recognizer.task`}
 				setResultat={setResultat}
 				className="min-w-[60dvw] min-h-[45dvw] border-2 border-blue-100"


### PR DESCRIPTION
Ajout de la possibilité de personnaliser la caméra en fournissant au détecteur des options supplémentaires (ex.: le score minimum, la listes de gestes à accepter, etc.).

Voir #9.